### PR TITLE
Fix bug with radio input color in error state

### DIFF
--- a/lib/molecules/Input/Radio/index.tsx
+++ b/lib/molecules/Input/Radio/index.tsx
@@ -3,6 +3,7 @@ import { CommonInputProps } from '../common';
 import styles from './styles.module.css';
 import { RowInput } from '../common/RowInput';
 import { useInputControls } from '../../../internal/hooks/useInputControls';
+import { useEffect } from 'react';
 
 export interface RadioProps extends CommonInputProps {
   /**
@@ -40,6 +41,21 @@ export function Radio(props: RadioProps) {
     onChange
   });
 
+  // Color for main checkbox and border
+  const checkboxColor = disabled
+    ? theme.colors.disabled
+    : errorText
+    ? theme.colors.error
+    : theme.colors.primary_dark;
+
+  // Update CSS var when checkbox color changes
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      '--tse-constellation-checkbox-color',
+      checkboxColor
+    );
+  }, [checkboxColor]);
+
   return (
     <RowInput
       inputFirst
@@ -57,9 +73,7 @@ export function Radio(props: RadioProps) {
             checked={internalChecked}
             className={styles.checkbox}
             style={{
-              border: `3px solid ${
-                errorText ? theme.colors.error : theme.colors.primary_dark
-              }`
+              border: `3px solid ${checkboxColor}`
             }}
             onChange={(e) => handleChange(e.target.checked)}
             disabled={disabled}

--- a/lib/molecules/Input/Radio/styles.module.css
+++ b/lib/molecules/Input/Radio/styles.module.css
@@ -1,3 +1,9 @@
+.root {
+  --tse-constellation-checkbox-color: var(
+    --tse-constellation-color-primary-dark
+  );
+}
+
 .checkboxContainer {
   position: relative;
   width: 24px;
@@ -37,7 +43,7 @@
   border-radius: 100%;
   position: absolute;
   top: 10%;
-  background: black;
+  background-color: var(--tse-constellation-checkbox-color);
   left: 10%;
   font-size: 32px;
 }


### PR DESCRIPTION
This PR fixes a minor bug in the `Radio` input molecule. The bug was that when the radio input was in an error state and checked, the circle would be filled in with black instead of red. I fixed it so that it is filled in with red now (see below screenshot).

![image](https://github.com/TritonSE/TSE-Constellation/assets/68413232/a0049938-d808-4a25-8781-1ba3eb10e8e8)
