### PR TITLE
Add fill color props to leadingIcon and trailingIcon on Button

### DIFF
--- a/lib/atoms/Button/index.tsx
+++ b/lib/atoms/Button/index.tsx
@@ -34,6 +34,14 @@ export type ButtonProps = {
    * Icon to display at the right of the button
    */
   trailingIcon?: IconName;
+  /**
+   * Fill color for the leading icon
+   */
+  leadingIconFill?: string;
+  /**
+   * Fill color for the trailing icon
+   */
+  trailingIconFill?: string;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 // See https://github.com/JedWatson/classnames for usage
@@ -52,6 +60,8 @@ export function Button(props: ButtonProps) {
     children,
     leadingIcon,
     trailingIcon,
+    leadingIconFill,
+    trailingIconFill,
     ...restProps
   } = props;
 
@@ -72,9 +82,13 @@ export function Button(props: ButtonProps) {
       {...restProps}
     >
       <div className={styles.row}>
-        {leadingIcon ? <Icon name={leadingIcon} fill={theme.colors.white} /> : null}
+        {leadingIcon ? (
+          <Icon name={leadingIcon} fill={leadingIconFill ?? theme.colors.white} />
+        ) : null}
         {children}
-        {trailingIcon ? <Icon name={trailingIcon} fill={theme.colors.white} /> : null}
+        {trailingIcon ? (
+          <Icon name={trailingIcon} fill={trailingIconFill ?? theme.colors.white} />
+        ) : null}
       </div>
     </button>
   );


### PR DESCRIPTION
`Button` component previously had less flexibility in customizing the fill colors of the leading icon and trailing icon. 

Add string props`trailingIconFill` and `leadingIconFill` to change the icon color. 